### PR TITLE
Hide the window border in fade mode

### DIFF
--- a/mintty-quake-console.ahk
+++ b/mintty-quake-console.ahk
@@ -148,7 +148,7 @@ Slide(Window, Dir)
 
       if (animationModeFade = 1)
       {
-        WinSet, Style, +0x040000, %Window% ; show window border
+        WinSet, Style, -0x040000, %Window% ; hide window border
           WinMove, %Window%,, WinLeft, ScreenTop
           dRate := animationStep/300*255
           dT := % (Dir = "In") ? currentTrans + dRate : currentTrans - dRate
@@ -159,7 +159,7 @@ Slide(Window, Dir)
       }
       else
       {
-          WinSet, Style, -0x040000, %Window% ; show window border
+          WinSet, Style, -0x040000, %Window% ; hide window border
           dRate := animationStep
           dY := % (Dir = "In") ? Ypos + dRate : Ypos - dRate
           WinMove, %Window%,,, dY


### PR DESCRIPTION
At the moment the fade mode has a window border, while the slide mode doesn't.
It might potentially be nice to have this as an option, but for now I've removed the border from fade mode to match the slide behaviour.
