### PR TITLE
Force process DPI awareness

### DIFF
--- a/mintty-quake-console.ahk
+++ b/mintty-quake-console.ahk
@@ -41,6 +41,9 @@ SetWinDelay, -1
 RegRead, cygwinRootDir, HKEY_LOCAL_MACHINE, SOFTWARE\Cygwin\setup, rootdir
 cygwinBinDir := cygwinRootDir . "\bin"
 
+; force process to be DPI aware
+DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
+
 ;*******************************************************************************
 ;               Preferences & Variables
 ;*******************************************************************************


### PR DESCRIPTION
This fixes an issue where the terminal window will miscalculate screen dimensions when moved between monitors with different DPI settings.